### PR TITLE
Removed sourcecode from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,3 @@ dist/
 node_modules/
 .DS_Store
 src/
-!src/ngx-uploader

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.2.1",
   "main": "bundles/ngx-uploader.umd.js",
   "module": "lib/index.js",
+  "typings": "lib/index",
   "scripts": {
     "start": "webpack-dev-server --env.client --env.serve --progress --hot",
     "start-server": "node ./dist/api/index.js",

--- a/tsconfig.bundle.json
+++ b/tsconfig.bundle.json
@@ -7,7 +7,7 @@
     "sourceMap": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "declaration": false,
+    "declaration": true,
     "lib": [
       "es2017",
       "dom"
@@ -15,9 +15,6 @@
     "outDir": "lib",
     "typeRoots": [
       "node_modules/@types"
-    ],
-    "types": [
-      "mocha"
     ]
   },
   "include": [


### PR DESCRIPTION
I used this package as a dependency in my project and ran into issues which caused my TSLint to fail, because it always lints imported dependencies of `*.ts` files (sadly there is no option that disables this).
This raised an issue, as TSLint was linting the source files of this project which are currently included in the package. As my Linter is stricter than anything that might be linting this project, it threw a diverse collection of errors, stopping me from building my project.

This pull request removes the src-folder from the package and introduces declaration-files which will from now on take care of the typing.

This relates to #336 and should not introduce new errors to importing.

Additionally, I removed the typing for mocha from the bundle build process, as `*.spec.ts` files are excluded anyways, no typings for mocha will be needed.