### PR TITLE
Support for #400, handling response headers after upload request

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ export interface UploadFile {
   progress: UploadProgress;
   response?: any; // response when upload is done (parsed JSON or string)
   responseStatus?: number; // response status code when upload is done
+  responseHeaders?: { [key: string]: string }; // response headers when upload is done
 }
 
 // output events emitted by ngx-uploader

--- a/src/ngx-uploader/classes/interfaces.ts
+++ b/src/ngx-uploader/classes/interfaces.ts
@@ -42,7 +42,7 @@ export interface UploadFile {
   responseStatus?: number;
   sub?: Subscription | any;
   nativeFile?: File;
-  headers?: { [key: string]: string };
+  responseHeaders?: { [key: string]: string };
 }
 
 export interface UploadOutput {

--- a/src/ngx-uploader/classes/interfaces.ts
+++ b/src/ngx-uploader/classes/interfaces.ts
@@ -42,7 +42,7 @@ export interface UploadFile {
   responseStatus?: number;
   sub?: Subscription | any;
   nativeFile?: File;
-  rawRequest?: XMLHttpRequest;
+  headers?: { [key: string]: string };
 }
 
 export interface UploadOutput {

--- a/src/ngx-uploader/classes/interfaces.ts
+++ b/src/ngx-uploader/classes/interfaces.ts
@@ -42,6 +42,7 @@ export interface UploadFile {
   responseStatus?: number;
   sub?: Subscription | any;
   nativeFile?: File;
+  rawRequest?: XMLHttpRequest;
 }
 
 export interface UploadOutput {

--- a/src/ngx-uploader/classes/ngx-uploader.class.ts
+++ b/src/ngx-uploader/classes/ngx-uploader.class.ts
@@ -205,7 +205,7 @@ export class NgUploaderService {
             file.response = xhr.response;
           }
 
-          file.headers = this.parseResponseHeaders(xhr.getAllResponseHeaders());
+          file.responseHeaders = this.parseResponseHeaders(xhr.getAllResponseHeaders());
 
           observer.next({ type: 'done', file: file });
 
@@ -300,7 +300,7 @@ export class NgUploaderService {
 
   private parseResponseHeaders(httpHeaders: ByteString) {
     if (!httpHeaders) {
-      return null;
+      return;
     }
     return httpHeaders.split('\n')
       .map(x => x.split(/: */, 2))

--- a/src/ngx-uploader/classes/ngx-uploader.class.ts
+++ b/src/ngx-uploader/classes/ngx-uploader.class.ts
@@ -299,12 +299,15 @@ export class NgUploaderService {
   }
 
   private parseResponseHeaders(httpHeaders: ByteString) {
-      return httpHeaders.split('\n')
-          .map(x => x.split(/: */, 2))
-          .filter(x => x[0])
-          .reduce((ac, x) => {
-              ac[x[0]] = x[1];
-              return ac;
-          }, {});
+    if (!httpHeaders) {
+      return null;
+    }
+    return httpHeaders.split('\n')
+      .map(x => x.split(/: */, 2))
+      .filter(x => x[0])
+      .reduce((ac, x) => {
+        ac[x[0]] = x[1];
+        return ac;
+      }, {});
   }
 }

--- a/src/ngx-uploader/classes/ngx-uploader.class.ts
+++ b/src/ngx-uploader/classes/ngx-uploader.class.ts
@@ -205,6 +205,8 @@ export class NgUploaderService {
             file.response = xhr.response;
           }
 
+          file.rawRequest = xhr;
+
           observer.next({ type: 'done', file: file });
 
           observer.complete();

--- a/src/ngx-uploader/classes/ngx-uploader.class.ts
+++ b/src/ngx-uploader/classes/ngx-uploader.class.ts
@@ -205,7 +205,7 @@ export class NgUploaderService {
             file.response = xhr.response;
           }
 
-          file.rawRequest = xhr;
+          file.headers = this.parseResponseHeaders(xhr.getAllResponseHeaders());
 
           observer.next({ type: 'done', file: file });
 
@@ -296,5 +296,15 @@ export class NgUploaderService {
       sub: undefined,
       nativeFile: file
     };
+  }
+
+  private parseResponseHeaders(httpHeaders: ByteString) {
+      return httpHeaders.split('\n')
+          .map(x => x.split(/: */, 2))
+          .filter(x => x[0])
+          .reduce((ac, x) => {
+              ac[x[0]] = x[1];
+              return ac;
+          }, {});
   }
 }


### PR DESCRIPTION
I found it pretty useful to retrieve a whole XHR object, so user can easily do call `file.rawRequest. getAllResponseHeaders()` or `file.rawRequest.getResponseHeader('X-MY-HEADER')`.