### PR TITLE
fix(uploadFile): change order of fields and files in body

### DIFF
--- a/src/ngx-uploader/classes/ngx-uploader.class.ts
+++ b/src/ngx-uploader/classes/ngx-uploader.class.ts
@@ -224,10 +224,10 @@ export class NgUploaderService {
           observer.complete();
         }
 
-        file.form.append(event.fieldName || 'file', uploadFile, uploadFile.name);
-
         Object.keys(data).forEach(key => file.form.append(key, data[key]));
         Object.keys(headers).forEach(key => xhr.setRequestHeader(key, headers[key]));
+
+        file.form.append(event.fieldName || 'file', uploadFile, uploadFile.name);
 
         this.serviceEvents.emit({ type: 'start', file: file });
         xhr.send(file.form);


### PR DESCRIPTION
This PR changes the order of files and fields in the request. This allows the fields to be read as the request is streamed to the server before handling the files. 

There was an old issue about this: https://github.com/bleenco/ngx-uploader/issues/186 and here is the old PR which solved that issue: https://github.com/bleenco/ngx-uploader/pull/187)
It seems that the fix was lost in some other commit, but this PR basically does the same as the old one.