### PR TITLE
This commit addresses the problem of not being able to upload the sam…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-uploader",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ngx-uploader/directives/ng-file-select.directive.ts
+++ b/src/ngx-uploader/directives/ng-file-select.directive.ts
@@ -26,6 +26,8 @@ export class NgFileSelectDirective implements OnInit, OnDestroy {
     this.upload = new NgUploaderService(concurrency, allowedContentTypes);
 
     this.el = this.elementRef.nativeElement;
+
+    this.el.addEventListener('click', this.clickListener, false);
     this.el.addEventListener('change', this.fileListener, false);
 
     this._sub.push(
@@ -43,6 +45,12 @@ export class NgFileSelectDirective implements OnInit, OnDestroy {
     if (this.el){
       this.el.removeEventListener('change', this.fileListener, false);
       this._sub.forEach(sub => sub.unsubscribe());
+    }
+  }
+
+  clickListener = () => {
+    if(this.el.value) {
+      this.el.value = '';
     }
   }
 


### PR DESCRIPTION
…e file twice.

Since the value property of the file component does not change, the change event does not fire preventing the user from starting the upload.

By adding a click handler on the input, the value is set to an empty string, causing the 'bug' to not happen.