### PR TITLE
Enables correct transfer of UTF-8 filenames

### DIFF
--- a/projects/ngx-uploader/src/lib/ngx-uploader.class.ts
+++ b/projects/ngx-uploader/src/lib/ngx-uploader.class.ts
@@ -230,7 +230,7 @@ export class NgUploaderService {
         Object.keys(data).forEach(key => file.form.append(key, data[key]));
         Object.keys(headers).forEach(key => xhr.setRequestHeader(key, headers[key]));
 
-        file.form.append(event.fieldName || 'file', uploadFile, uploadFile.name);
+        file.form.append(event.fieldName || 'file', uploadFile, encodeURIComponent(uploadFile.name));
 
         this.serviceEvents.emit({ type: 'start', file: file });
         xhr.send(file.form);


### PR DESCRIPTION
Currently filenames are not encoded properly in the form so that non ASCII filenames cannot be interpreted correctly on serverside. This fix URI-encodes the filename and preserve the original filename.