### PR TITLE
update readme with updated npm cli shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://ngx-uploader.com
 Add `ngx-uploader` module as dependency to your project.
 
 ```console
-npm install ngx-uploader --save
+npm i ngx-uploader
 ```
 
 or using `yarn`:


### PR DESCRIPTION
`i` has been added as shorthand for `install` and `--save` is defaulted to true in latest npm cli. The replacement LoC in the readme is 100% equivalent shorthand that may help save folks time for this (and other) installs.