### PR TITLE
feat: Handling Failed Uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-uploader-demo",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4322,7 +4322,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4343,12 +4344,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4363,17 +4366,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4490,7 +4496,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4502,6 +4509,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4516,6 +4524,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4523,12 +4532,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4547,6 +4558,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4627,7 +4639,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4639,6 +4652,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4724,7 +4738,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4760,6 +4775,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4779,6 +4795,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4822,12 +4839,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-uploader-demo",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bleenco/ngx-uploader.git"

--- a/projects/ngx-uploader/src/lib/interfaces.ts
+++ b/projects/ngx-uploader/src/lib/interfaces.ts
@@ -15,7 +15,8 @@ export enum UploadStatus {
   Queue,
   Uploading,
   Done,
-  Cancelled
+  Cancelled,
+  Failed
 }
 
 export interface UploadProgress {
@@ -44,12 +45,12 @@ export interface UploadFile {
   responseStatus?: number;
   sub?: Subscription | any;
   nativeFile?: File;
-  responseHeaders?: { [key: string]: string };
+  responseHeaders?: Object;
 }
 
 export interface UploadOutput {
   type: 'addedToQueue' | 'allAddedToQueue' | 'uploading' | 'done' | 'start' | 'cancelled' | 'dragOver'
-      | 'dragOut' | 'drop' | 'removed' | 'removedAll' | 'rejected';
+      | 'dragOut' | 'drop' | 'removed' | 'removedAll' | 'rejected' | 'failed';
   file?: UploadFile;
   nativeFile?: File;
 }

--- a/projects/ngx-uploader/src/lib/ngx-uploader.class.ts
+++ b/projects/ngx-uploader/src/lib/ngx-uploader.class.ts
@@ -191,6 +191,25 @@ export class NgUploaderService {
         }
       }, false);
 
+      xhr.addEventListener('load', (e) => {
+        if (xhr.status < 400) {
+        } else {
+          file.responseStatus = xhr.status;
+
+          try {
+            file.response = JSON.parse(xhr.response);
+          } catch (e) {
+            file.response = xhr.response;
+          }
+
+          file.responseHeaders = this.parseResponseHeaders(xhr.getAllResponseHeaders());
+          file.progress.status = UploadStatus.Failed;
+
+          observer.next({ type: 'failed', file: file });
+          observer.complete();
+        }
+      });
+
       xhr.upload.addEventListener('error', (e: Event) => {
         observer.error(e);
         observer.complete();

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -42,14 +42,15 @@
                   </div>
                   <div class="progress-content">
                     <div class="progress">
-                      <span class="bar" [style.width]="f?.progress?.data?.percentage + '%'" [class.is-done]="f?.progress?.data?.percentage === 100"></span>
+                      <span class="bar" [style.width]="f?.progress?.data?.percentage + '%'" [class.is-done]="f?.progress?.data?.percentage === 100" [class.is-failed]="f.progress?.status === 4"></span>
                     </div>
                   </div>
                   <div class="progress-text-content">
-                    <span class="progress-text" [class.is-done]="f?.progress?.data?.percentage === 100">
+                    <span class="progress-text" [class.is-done]="f?.progress?.data?.percentage === 100" [class.is-failed]="f.progress?.status === 4">
                       <span>{{ f.progress?.data?.percentage }}% </span>
                       <span *ngIf="f.progress?.data?.percentage !== 100">Uploading...</span>
-                      <span *ngIf="f.progress?.data?.percentage === 100">Done</span>
+                      <span *ngIf="f.progress?.status !== 4 && f.progress?.data?.percentage === 100">Done</span>
+                      <span *ngIf="f.progress?.status === 4">Failed<span *ngIf="!!f.response?.detail"> [{{ f.response?.detail }}]</span></span>
                     </span>
                     <span class="speed-and-eta-text" *ngIf="f.progress?.data?.percentage !== 0 && f.progress?.data?.percentage !== 100">
                       <span>{{ f.progress?.data?.speedHuman }} </span>

--- a/src/styles/app.sass
+++ b/src/styles/app.sass
@@ -170,6 +170,9 @@ body
               &.is-done
                 background: $green
 
+              &.is-done
+                background: $red
+
         .progress-text-content
           display: flex
           align-items: center
@@ -184,6 +187,9 @@ body
 
             &.is-done
               color: $green
+
+            &.is-failed
+              color: $red
 
           .speed-and-eta-text
             font-size: 13px


### PR DESCRIPTION
Adding the ability to handle failed uploads. This is done by adding the 'load' event on the XMLHttpRequrest and looking for a status < 400. Instead of bubbling an error I went with the approach of setting the file UploadStatus to Failed (new enum value) and pushing it in the observable state with a type of 'failed'.

I felt this would be the least disruptive and most simple to implement.